### PR TITLE
Catch validation errors

### DIFF
--- a/lib/frontend/socket.js
+++ b/lib/frontend/socket.js
@@ -54,7 +54,12 @@ function makeSocket (remote) {
 export default class WeConnector extends Connector {
 
     connect (callback = noop) {
-        const socket = this.socket = makeSocket(this.remote);
+
+        try {
+            const socket = this.socket = makeSocket(this.remote);
+        } catch (e) {
+            return callback(e);
+        }
 
         bubble('error', socket, this, 'bubbleOpen');
 


### PR DESCRIPTION
Without this, websocket will just throw an Error on construction instead of triggering a callback.