### PR TITLE
Allow partial reports to be sent to the adder

### DIFF
--- a/lib/frontend/reporter.js
+++ b/lib/frontend/reporter.js
@@ -1,5 +1,5 @@
 import Packets from './packets';
-import {find, noop} from '../util';
+import {find, noop, addIf} from '../util';
 
 /**
  * The reporter is responsible for building report data and
@@ -48,8 +48,8 @@ export default class Reporter {
             const left = find(report.tactile, (l) => l.id === right.id);
 
             if (left !== undefined) {
-                left.down += right.down;
-                left.up += right.up;
+                left.down = addIf(left.down, right.down);
+                left.up = addIf(left.up, right.up);
             } else {
                 report.tactile.push(right);
             }

--- a/lib/util.js
+++ b/lib/util.js
@@ -65,6 +65,17 @@ export function strRepeat (str, times) {
 }
 
 /**
+ * Adds a and b and returns their result. If either A or B is falsey
+ * (undefined, null, NaN, etc), it'll treat it as zero.
+ * @param {Number} a
+ * @param {Number} b
+ * @return {Number}
+ */
+export function addIf (a, b) {
+    return (a || 0) + (b || 0);
+}
+
+/**
  * Indents the string n times.
  * @param  {String} str
  * @param  {Number} times

--- a/test/unit/frontend/reporter.test.js
+++ b/test/unit/frontend/reporter.test.js
@@ -79,4 +79,34 @@ describe('reporter', () => {
             tactile: [{ id: 2, down: 4, up: 3 }, { id: 3, down: 1, up: 1 }]
         });
     });
+
+    it('fixes issue WatchBeam/frontend#889', function () {
+        reporter.add({
+            tactile: [
+                { id: 1, down: 1 },
+                { id: 2, up: 1 },
+                { id: 3, down: 1 },
+                { id: 4, up: 1 },
+            ]
+        });
+
+        reporter.add({
+            tactile: [
+                { id: 3, up: 1 },
+                { id: 4, up: 1 },
+            ]
+        });
+
+        clock.tick(51);
+        expect(mock.send.args.length).to.equal(1);
+        expect(mock.send.args[0][0].props).to.deep.equal({
+            joystick: [],
+            tactile: [
+                { id: 1, down: 1 },
+                { id: 2, up: 1 },
+                { id: 3, down: 1, up: 1 },
+                { id: 4, up: 2, down: 0 },
+            ]
+        });
+    });
 });


### PR DESCRIPTION
Previously we dependent on the behaviour of frontend adding complete reports for tactiles to the reporter on every input. This behaviour was changed on the frontend but not updated here, leading to NaN's being generated and sent to Tetrisd. Tetrisd would then respond with an error, but Tetrisd errors are not displayed nor logged on our frontend (another todo) leading to confusion :stuck_out_tongue: Mostly I am unsure about why this wasn't a severe issue in the past, but here's a fix for it.

Fixes https://github.com/WatchBeam/frontend/issues/889