### PR TITLE
Heartbeats

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,6 +10,7 @@ export default class Client extends EventEmitter {
         this.connect = this.newConnector();
 
         bubble('error', this.connect, this);
+        bubble('close', this.connect, this);
 
         // By default Node throws when errors are emitted without a listener.
         // But it's quite bad at printing out those errors. We'll watch

--- a/lib/connector.js
+++ b/lib/connector.js
@@ -35,6 +35,8 @@ export default class Connector extends EventEmitter {
         const socket = this.socket = generator(this.remote);
 
         bubble('error', socket, this, 'bubbleOpen');
+        // Always bubble close
+        bubble('close', socket, this);
 
         socket.once('open', () => {
             this.emit('connect');

--- a/lib/heartbeats.js
+++ b/lib/heartbeats.js
@@ -1,0 +1,17 @@
+
+import sendHeartbeats from 'ws-heartbeats';
+/**
+ * Given a websocket instance this function adds heartbeat capabilities
+ * from the ws-heartbeats module to it.
+ * @param {WebSocket} websocket
+ */
+export default function addHeartBeats(websocket, options = {}) {
+    // Very basic for now but allows for further expansion to add options
+    // to be passed to the hearbeat handler
+
+    // We wait for the websocket to be open before adding
+    // heartbeats so that we do not get false positives
+    websocket.on('open', () => {
+        sendHeartbeats(websocket, options);
+    });
+}

--- a/lib/heartbeats.js
+++ b/lib/heartbeats.js
@@ -1,11 +1,17 @@
 
 import sendHeartbeats from 'ws-heartbeats';
+
+const defaultOptions = {
+    heartbeatInterval: 3000,
+    heartbeatTimeout: 2000,
+};
+
 /**
  * Given a websocket instance this function adds heartbeat capabilities
  * from the ws-heartbeats module to it.
  * @param {WebSocket} websocket
  */
-export default function addHeartBeats(websocket, options = {}) {
+export default function addHeartBeats(websocket, options = defaultOptions) {
     // Very basic for now but allows for further expansion to add options
     // to be passed to the hearbeat handler
 

--- a/lib/socketMaker.js
+++ b/lib/socketMaker.js
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import addHeartBeats from './heartbeats';
 
 // window will be undefined in node.js
 const isNode = typeof window === 'undefined';
@@ -42,6 +43,7 @@ function wrapDOM(socket) {
  * @return {Socket}
  */
 function wrapNode(socket) {
+    addHeartBeats(socket);
     return socket;
 }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lodash.isplainobject": "^4.0.1",
     "protobufjs": "^4.0.0",
     "varint": "^4.0.0",
-    "ws": "^0.8.0"
+    "ws": "^0.8.0",
+    "ws-heartbeats": "^1.0.0"
   },
   "devDependencies": {
     "async": "^1.4.2",

--- a/test/unit/connector.test.js
+++ b/test/unit/connector.test.js
@@ -1,5 +1,6 @@
 import Connector from '../../lib/connector';
-import {expect} from 'chai';
+import { expect } from 'chai';
+import { EventEmitter } from 'events';
 
 describe('connector', () => {
     it('bubbles error correctly', () => {
@@ -13,5 +14,15 @@ describe('connector', () => {
         c.setOpen(false);
         c.bubbleOpen('error', 'asdf');
         expect(i).to.equal(1);
-    })
+    });
+
+    it('bubbles close correctly', () => {
+        const c = new Connector('');
+        const emitter = new EventEmitter();
+        let i = false;
+        c.connect(() => {}, () => emitter);
+        c.on('close', () => { i = true; });
+        emitter.emit('close');
+        expect(i).to.be.ok;
+    });
 });

--- a/test/unit/socketMaker.test.js
+++ b/test/unit/socketMaker.test.js
@@ -1,0 +1,10 @@
+import socketMaker from '../../lib/socketMaker';
+import { expect } from 'chai';
+
+describe('socketMaker', () => {
+    it('adds heartbeats handling to a socket', () => {
+        const socket = socketMaker('ws://127.0.0.1');
+        socket.emit('open');
+        expect(socket.listeners('pong').length).to.be.above(0);
+    });
+});


### PR DESCRIPTION
This relates to #5 

I'm seeing connection reliability issues on most of the streams that use my node integration and a brief discussion with @connor4312 suggested that ws Heartbeats might help us detect the healthiness of the connection. 

This adds heartbeats to the the underlying node websocket within the library.

It makes use of [ws-heartbeats](https://www.npmjs.com/package/ws-heartbeats) which unfortunately doesn't have a public repository anywhere. I downloaded it from the registry and poke around it looks like a very close match to what I would of done had I implemented them from scratch anyway.

As the WS connection is closed if heartbeats are not being received I've also bubbled the `close` event up to the client level. 

With this in place integration developers can more accurately react to the websocket state and the Youplay team and I can sleep a little easier :)

