### PR TITLE
Throw an error on a ping timeout

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -52,3 +52,9 @@ export const AssertionError = extendError('AssertionError');
  * connect to the websocket.
  */
 export const UnexpectedServerResponse = extendError('UnexpectedServerResponse');
+
+/**
+ * Emitted on sockets if a ping frame is sent without a pong message
+ * being returned after a certain interval.
+ */
+export const PingTimeoutError = extendError('PingTimeoutError');

--- a/lib/heartbeats.js
+++ b/lib/heartbeats.js
@@ -1,3 +1,5 @@
+import { PingTimeoutError } from './errors';
+
 export default class Heartbeat {
 
     /**
@@ -48,7 +50,10 @@ export default class Heartbeat {
 
         this._timers = [
             setTimeout(() => this._ping(), this._interval),
-            setTimeout(() => this._socket.close(), this._interval + this._timeout),
+            setTimeout(() => {
+                this._socket.emit('error', new PingTimeoutError());
+                this._socket.close();
+            }, this._interval + this._timeout),
         ];
     }
 

--- a/test/unit/heartbeats.test.js
+++ b/test/unit/heartbeats.test.js
@@ -1,4 +1,5 @@
 import Heartbeats from '../../lib/heartbeats';
+import { PingTimeoutError } from '../../lib/errors';
 import { EventEmitter } from 'events';
 import { expect } from 'chai';
 import sinon from 'sinon'
@@ -31,11 +32,16 @@ describe('heartbeats', () => {
     });
 
     it('closes the socket without a response after a timeout', () => {
+        let err = null;
+        socket.once('error', (e) => { err = e });
+
         expect(socket.close.called).to.be.false;
         clock.tick(119);
         expect(socket.close.called).to.be.false;
+        expect(err).to.be.null;
         clock.tick(2);
         expect(socket.close.called).to.be.true;
+        expect(err).to.be.an.instanceof(PingTimeoutError);
     });
 
     it('updates the time when touched', () => {


### PR DESCRIPTION
Previously on timeout, we were closing the socket without emitting an error. This resulted in clients who depended on errors being thrown to reconnect (such as our frontend!) to not reconnect.